### PR TITLE
Just a hair more documentation ;)

### DIFF
--- a/riddle/getting_started.textile
+++ b/riddle/getting_started.textile
@@ -62,4 +62,8 @@ Documentation lacking (although this feature is only for Sphinx 0.9.9, so maybe 
 
 h3. Configuration
 
-Documentation lacking, but Riddle's configuration objects mirror Sphinx's, so it should be pretty easy to figure out.
+Documentation lacking, but Riddle's configuration objects mirror Sphinx's, so it should be pretty easy to figure out.  Some of its usage can also be inferred by studying the Configuration model in "ThinkingSphinx":https://github.com/freelancing-god/thinking-sphinx/ .
+
+h3. Controller
+
+Riddle's controller object allows you to control the operation of sphinx (starting, stopping, indexing...) in ruby.  Documentation is lacking, but some of its usage can be inferred by studying the Test and Configutation models in "ThinkingSphinx":https://github.com/freelancing-god/thinking-sphinx/ .


### PR DESCRIPTION
Since ThinkingSphinx doesn't support DataMapper yet,  I think it's a good idea to reveal the Controller and Configuration objects that it uses so that people like myself have a starting place in case we want to run tests, or interact with sphinx etc.  So I linked to ThinkingSphinx models that might be helpful for reference until there is documentation.
